### PR TITLE
[Project A][MacSilicon][hjungwoo01] Upgrade to Java 17

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,9 +20,22 @@ checkstyle {
     toolVersion = '10.2'
 }
 
+def pathToFx = System.getenv('PATH_TO_FX')
+
 test {
     useJUnitPlatform()
     finalizedBy jacocoTestReport
+    jvmArgs = [
+            '--module-path', "${pathToFx}",
+            '--add-modules', 'javafx.controls,javafx.fxml'
+    ]
+}
+
+application {
+    applicationDefaultJvmArgs = [
+            '--module-path', "${pathToFx}",
+            '--add-modules', 'javafx.controls,javafx.fxml'
+    ]
 }
 
 task coverage(type: JacocoReport) {
@@ -42,7 +55,7 @@ task coverage(type: JacocoReport) {
 
 dependencies {
     String jUnitVersion = '5.4.0'
-    String javaFxVersion = '17.0.7'
+    String javaFxVersion = '17.0.11'
 
     implementation group: 'org.openjfx', name: 'javafx-base', version: javaFxVersion, classifier: 'win'
     implementation group: 'org.openjfx', name: 'javafx-base', version: javaFxVersion, classifier: 'mac'
@@ -61,7 +74,6 @@ dependencies {
     implementation group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: '2.7.4'
 
     testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: jUnitVersion
-
     testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: jUnitVersion
 }
 


### PR DESCRIPTION
## Migrate to Java 17 and Update Gradle for Mac Silicon Compatibility

### Description

This pull request updates the `build.gradle` file to ensure compatibility with Java 17 and JavaFX on Mac Silicon (ARM architecture).

### Details

- **OS Used:** macOS on an M3 MacBook Pro
- **JDK Distribution Used:** 
  - openjdk version "17.0.11" 2024-04-16 LTS
  - OpenJDK Runtime Environment Corretto-17.0.11.9.1 (build 17.0.11+9-LTS)
  - OpenJDK 64-Bit Server VM Corretto-17.0.11.9.1 (build 17.0.11+9-LTS, mixed mode, sharing)
- **IDE Used:** IntelliJ IDEA
- **Link to JAR File:** [Download the JAR file](https://github.com/hjungwoo01/AB3-J17/releases/tag/v1.0-java17-mac-silicon)

### Noteworthy Information

- **Build Configuration:** Updated `build.gradle` to include the necessary JavaFX modules for Mac Silicon.
- **Running the JAR:**
  - The JAR file cannot be opened by double-clicking.
  - To run the JAR file, you need to set up an alias in your `~/.zshrc` file and use the `runjavafx` command.
- **Setting Up the Alias:**
  1. Update your `~/.zshrc` file with the following lines:
     ```sh
     export JAVA_HOME=`/usr/libexec/java_home -v 17`
     export PATH="$JAVA_HOME/bin:$PATH"
     export PATH_TO_FX=~/path/to/javafx-sdk-17.0.11/lib

     alias runjavafx="java --module-path $PATH_TO_FX --add-modules=javafx.controls,javafx.fxml"
     ```
  2. Apply the changes by running:
     ```sh
     source ~/.zshrc
     ```
  3. Run the JAR file using:
     ```sh
     runjavafx -jar path/to/your-fat-jar-file.jar
     ```
- **Issues Faced:** Had to update `build.gradle` to ensure Gradle builds work with Mac Silicon architecture.