### PR TITLE
[Project A][MacSilicon][Kenneth Seet] Upgrade to Java 17

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -29,10 +29,10 @@ jobs:
       - name: Validate Gradle Wrapper
         uses: gradle/wrapper-validation-action@v1
 
-      - name: Setup JDK 11
+      - name: Setup JDK 17
         uses: actions/setup-java@v1
         with:
-          java-version: '11'
+          java-version: '17'
           java-package: jdk+fx
 
       - name: Build and check with Gradle

--- a/build.gradle
+++ b/build.gradle
@@ -8,8 +8,8 @@ plugins {
 
 mainClassName = 'seedu.address.Main'
 
-sourceCompatibility = JavaVersion.VERSION_11
-targetCompatibility = JavaVersion.VERSION_11
+sourceCompatibility = JavaVersion.VERSION_17
+targetCompatibility = JavaVersion.VERSION_17
 
 repositories {
     mavenCentral()

--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -317,7 +317,7 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
 
 ### Non-Functional Requirements
 
-1.  Should work on any _mainstream OS_ as long as it has Java `11` or above installed.
+1.  Should work on any _mainstream OS_ as long as it has Java `17` or above installed.
 2.  Should be able to hold up to 1000 persons without a noticeable sluggishness in performance for typical usage.
 3.  A user with above average typing speed for regular English text (i.e. not code, not system admin commands) should be able to accomplish most of the tasks faster using commands than using the mouse.
 

--- a/docs/SettingUp.md
+++ b/docs/SettingUp.md
@@ -19,7 +19,9 @@ Follow the steps in the following guide precisely. Things will not work out if y
 First, **fork** this repo, and **clone** the fork into your computer.
 
 If you plan to use Intellij IDEA (highly recommended):
-1. **Configure the JDK**: Follow the guide [_[se-edu/guides] IDEA: Configuring the JDK_](https://se-education.org/guides/tutorials/intellijJdk.html) to to ensure Intellij is configured to use **JDK 11**.
+1. **Configure the JDK**: Follow the guide [_[se-edu/guides] IDEA: Configuring the JDK_]
+   (https://se-education.org/guides/tutorials/intellijJdk.html) to ensure Intellij is configured 
+   to use **JDK 17**.
 1. **Import the project as a Gradle project**: Follow the guide [_[se-edu/guides] IDEA: Importing a Gradle project_](https://se-education.org/guides/tutorials/intellijImportGradleProject.html) to import the project into IDEA.<br>
   :exclamation: Note: Importing a Gradle project is slightly different from importing a normal Java project.
 1. **Verify the setup**:

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -12,7 +12,7 @@ AddressBook Level 3 (AB3) is a **desktop app for managing contacts, optimized fo
 
 ## Quick start
 
-1. Ensure you have Java `11` or above installed in your Computer.
+1. Ensure you have Java `17` or above installed in your Computer.
 
 1. Download the latest `addressbook.jar` from [here](https://github.com/se-edu/addressbook-level3/releases).
 

--- a/src/main/java/seedu/address/Main.java
+++ b/src/main/java/seedu/address/Main.java
@@ -35,7 +35,7 @@ public class Main {
         // the user (if looking at the log output) that the said warning appearing in the log
         // can be ignored.
 
-        logger.warning("The warning about Unsupported JavaFX configuration below can be ignored.");
+        logger.warning("The warning about Unsupported JavaFX configuration below (if any) can be ignored.");
         Application.launch(MainApp.class, args);
     }
 }

--- a/src/main/java/seedu/address/Main.java
+++ b/src/main/java/seedu/address/Main.java
@@ -25,6 +25,17 @@ public class Main {
     private static Logger logger = LogsCenter.getLogger(Main.class);
 
     public static void main(String[] args) {
+
+        // As per https://github.com/openjdk/jfx/blob/master/doc-files/release-notes-16.md
+        // JavaFX 16 (or later) runtime logs a warning at startup if JavaFX classes are loaded from
+        // the classpath instead of a module.
+        // Our application does not use Java modules yet. Even if it did, modules are ignored when
+        // packed into a FAT Jar file (as we do), which means this warning will persist even then.
+        // The warning however, can be safely ignored. Thus, the following log informs
+        // the user (if looking at the log output) that the said warning appearing in the log
+        // can be ignored.
+
+        logger.warning("The warning about Unsupported JavaFX configuration below can be ignored.");
         Application.launch(MainApp.class, args);
     }
 }

--- a/src/main/java/seedu/address/Main.java
+++ b/src/main/java/seedu/address/Main.java
@@ -25,17 +25,6 @@ public class Main {
     private static Logger logger = LogsCenter.getLogger(Main.class);
 
     public static void main(String[] args) {
-
-        // As per https://github.com/openjdk/jfx/blob/master/doc-files/release-notes-16.md
-        // JavaFX 16 (or later) runtime logs a warning at startup if JavaFX classes are loaded from
-        // the classpath instead of a module.
-        // Our application does not use Java modules yet. Even if it did, modules are ignored when
-        // packed into a FAT Jar file (as we do), which means this warning will persist even then.
-        // The warning however, can be safely ignored. Thus, the following log informs
-        // the user (if looking at the log output) that the said warning appearing in the log
-        // can be ignored.
-
-        logger.warning("The warning about Unsupported JavaFX configuration below can be ignored.");
         Application.launch(MainApp.class, args);
     }
 }


### PR DESCRIPTION
### Description

This pull request includes updates to the documentation and the `gradle.yml` file to reflect the migration of the project to Java 17. Additionally, various JDK distributions were tested for compatibility with our codebase.

#### Environment Setup
- **Operating System:** MacOS Sonoma 14.2.1 (23C71)
- **JDK Distributions Tested:** 
  - 17.0.11.fx-zulu
  - 17.0.11.fx-librca
- **IDE Used:** IntelliJ IDEA 2023.2.1 (Ultimate Edition)
- **Link to JAR File:** [Download MacSilicon-KennethSeet.jar](https://github.com/itstrueitstrueitsrealitsreal/AB3-J17/releases/download/ms1/MacSilicon-KennethSeet.jar)

#### Issues Encountered
**Running AB3 on ARM64 Systems:**

As an M1 Mac user, I encountered compatibility issues with certain Java versions. Non-supported SDKs would lead to a `java.lang.UnsatisfiedLinkError` indicating an 'incompatible architecture'—my machine uses ARM64, but the application required X86-64.

To resolve this, it's necessary to install an ARM64 compatible SDK with JavaFX bundled. However, constantly switching between different SDKs for various needs can be cumbersome.

During CS2103 in AY23/24 Semester 2, I discovered [SDKMAN!](https://sdkman.io/), a UNIX command-line tool that facilitates switching between Java SDK versions. This tool proved essential as I needed Java 17 for teaching CS2030 and Java 11 for CS2103.

For my system, only the JDK versions `17.0.11.fx-zulu` and `17.0.11.fx-librca` were compatible.

#### Suggestion for Future Iterations
Considering the growing popularity of ARM64 machines, documenting the use of SDKMAN! for managing and switching Java SDKs could be beneficial for future courses.

