### PR TITLE
[Project A][MacSilicon][gongg21] Upgrade to Java 17

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,8 +8,8 @@ plugins {
 
 mainClassName = 'seedu.address.Main'
 
-sourceCompatibility = JavaVersion.VERSION_11
-targetCompatibility = JavaVersion.VERSION_11
+sourceCompatibility = JavaVersion.VERSION_17
+targetCompatibility = JavaVersion.VERSION_17
 
 repositories {
     mavenCentral()
@@ -42,18 +42,22 @@ task coverage(type: JacocoReport) {
 
 dependencies {
     String jUnitVersion = '5.4.0'
-    String javaFxVersion = '17.0.7'
+    String javaFxVersion = '17.0.11'
 
     implementation group: 'org.openjfx', name: 'javafx-base', version: javaFxVersion, classifier: 'win'
+    implementation group: 'org.openjfx', name: 'javafx-base', version: javaFxVersion, classifier: 'mac-aarch64'
     implementation group: 'org.openjfx', name: 'javafx-base', version: javaFxVersion, classifier: 'mac'
     implementation group: 'org.openjfx', name: 'javafx-base', version: javaFxVersion, classifier: 'linux'
     implementation group: 'org.openjfx', name: 'javafx-controls', version: javaFxVersion, classifier: 'win'
+    implementation group: 'org.openjfx', name: 'javafx-controls', version: javaFxVersion, classifier: 'mac-aarch64'
     implementation group: 'org.openjfx', name: 'javafx-controls', version: javaFxVersion, classifier: 'mac'
     implementation group: 'org.openjfx', name: 'javafx-controls', version: javaFxVersion, classifier: 'linux'
     implementation group: 'org.openjfx', name: 'javafx-fxml', version: javaFxVersion, classifier: 'win'
+    implementation group: 'org.openjfx', name: 'javafx-fxml', version: javaFxVersion, classifier: 'mac-aarch64'
     implementation group: 'org.openjfx', name: 'javafx-fxml', version: javaFxVersion, classifier: 'mac'
     implementation group: 'org.openjfx', name: 'javafx-fxml', version: javaFxVersion, classifier: 'linux'
     implementation group: 'org.openjfx', name: 'javafx-graphics', version: javaFxVersion, classifier: 'win'
+    implementation group: 'org.openjfx', name: 'javafx-graphics', version: javaFxVersion, classifier: 'mac-aarch64'
     implementation group: 'org.openjfx', name: 'javafx-graphics', version: javaFxVersion, classifier: 'mac'
     implementation group: 'org.openjfx', name: 'javafx-graphics', version: javaFxVersion, classifier: 'linux'
 

--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -317,7 +317,7 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
 
 ### Non-Functional Requirements
 
-1.  Should work on any _mainstream OS_ as long as it has Java `11` or above installed.
+1.  Should work on any _mainstream OS_ as long as it has Java `17` or above installed.
 2.  Should be able to hold up to 1000 persons without a noticeable sluggishness in performance for typical usage.
 3.  A user with above average typing speed for regular English text (i.e. not code, not system admin commands) should be able to accomplish most of the tasks faster using commands than using the mouse.
 

--- a/docs/SettingUp.md
+++ b/docs/SettingUp.md
@@ -19,7 +19,7 @@ Follow the steps in the following guide precisely. Things will not work out if y
 First, **fork** this repo, and **clone** the fork into your computer.
 
 If you plan to use Intellij IDEA (highly recommended):
-1. **Configure the JDK**: Follow the guide [_[se-edu/guides] IDEA: Configuring the JDK_](https://se-education.org/guides/tutorials/intellijJdk.html) to to ensure Intellij is configured to use **JDK 11**.
+1. **Configure the JDK**: Follow the guide [_[se-edu/guides] IDEA: Configuring the JDK_](https://se-education.org/guides/tutorials/intellijJdk.html) to to ensure Intellij is configured to use **JDK 17**.
 1. **Import the project as a Gradle project**: Follow the guide [_[se-edu/guides] IDEA: Importing a Gradle project_](https://se-education.org/guides/tutorials/intellijImportGradleProject.html) to import the project into IDEA.<br>
   :exclamation: Note: Importing a Gradle project is slightly different from importing a normal Java project.
 1. **Verify the setup**:

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -12,7 +12,7 @@ AddressBook Level 3 (AB3) is a **desktop app for managing contacts, optimized fo
 
 ## Quick start
 
-1. Ensure you have Java `11` or above installed in your Computer.
+1. Ensure you have Java `17` or above installed in your Computer.
 
 1. Download the latest `addressbook.jar` from [here](https://github.com/se-edu/addressbook-level3/releases).
 


### PR DESCRIPTION
## Details
OS used: **macOS Sonoma 14.4.1** with M1 Pro
JDK distribution used: **[Azul Zulu JDK FX 17](https://www.azul.com/downloads/?version=java-17-lts&os=macos&package=jdk-fx#zulu)**
IDE used: **IntelliJ IDEA 2022.3.1**
**[Link to uploaded JAR file](https://github.com/gongg21/AB3-J17/releases/download/v1.0/MacSilicon-gongg21.jar)**

## Resolving Compatibility Issues Faced
Ran into `Loading library prism_sw from resource failed: java.lang.UnsatisfiedLinkError ... (mach-o file, but is an incompatible architecture (have 'x86_64', need 'arm64e' or 'arm64'))` error when switching JDKs.

There is a need to add additional lines in the `build.gradle` file under `dependencies` to resolve compatibility issues regarding the JDK. This includes the lines ending with `classifier: 'mac-aarch64'`. Specifically for me using an M1 Mac, they must be placed **above the ones** ending with `classifier: 'mac'`, otherwise the Gradle tasks will fail.

From what I understand, Gradle will try to find the first compatible dependency during resolution. This means if the same code here were to be used on an Intel Mac, the Gradle tasks would fail as Gradle would try to resolve using the 'mac-aarch64' libraries. As this may affect/apply to students in future, I believe it is good to note.

## Additional
Also updated documentation to reflect support for Java 17.