### PR TITLE
Revert TLS workaround after upgrading to JDK17

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,2 @@
 org.gradle.parallel=false
 org.gradle.jvmargs=-XX:MaxMetaspaceSize=512m -XX:+HeapDumpOnOutOfMemoryError -Xmx1024m -Dfile.encoding=utf-8
-
-# TODO: This is a workaround for a JDK11 bug which causes test coverage upload to fail.
-# Remove it when https://bugs.openjdk.java.net/browse/JDK-8221253 is fixed.
-systemProp.jdk.tls.client.protocols="TLSv1,TLSv1.1,TLSv1.2"


### PR DESCRIPTION
Closes #18 