### PR TITLE
Update build.gradle for Mac Silicon Compatibility

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,6 +8,8 @@ plugins {
 
 mainClassName = 'seedu.address.Main'
 
+def pathToFx = System.getenv('PATH_TO_FX')
+
 sourceCompatibility = JavaVersion.VERSION_17
 targetCompatibility = JavaVersion.VERSION_17
 
@@ -23,6 +25,17 @@ checkstyle {
 test {
     useJUnitPlatform()
     finalizedBy jacocoTestReport
+    jvmArgs = [
+            '--module-path', "${pathToFx}",
+            '--add-modules', 'javafx.controls,javafx.fxml'
+    ]
+}
+
+application {
+    applicationDefaultJvmArgs = [
+            '--module-path', "${pathToFx}",
+            '--add-modules', 'javafx.controls,javafx.fxml'
+    ]
 }
 
 task coverage(type: JacocoReport) {


### PR DESCRIPTION
#### Summary
This pull request introduces changes to the `build.gradle` file to ensure compatibility with JavaFX on Mac Silicon (ARM architecture). These changes are necessary to pass all tests and ensure the application runs correctly using the IntelliJ run button on Mac Silicon devices.

#### Changes Made
1. **Environment Variable for JavaFX Path:**
   - Added a line to retrieve the JavaFX path from the environment variable `PATH_TO_FX`.

2. **Test Configuration:**
   - Updated the `test` block in `build.gradle` to include the JavaFX module path and required modules.
   ```groovy
   def pathToFx = System.getenv('PATH_TO_FX')

   test {
       useJUnitPlatform()
       finalizedBy jacocoTestReport
       jvmArgs = [
               '--module-path', "${pathToFx}",
               '--add-modules', 'javafx.controls,javafx.fxml'
       ]
   }
   ```

3. **Application Configuration:**
   - Updated the `application` block to set default JVM arguments for running the application with JavaFX modules.
   ```groovy
   application {
       applicationDefaultJvmArgs = [
               '--module-path', "${pathToFx}",
               '--add-modules', 'javafx.controls,javafx.fxml'
       ]
   }
   ```

#### Justification
- **Issue:** Without these changes, running the build in IntelliJ results in a failure for the `AppUtilTest.getImage_exitingImage()` test, while the same build passes when using the `./gradlew clean build` command.
- **Resolution:** By explicitly specifying the JavaFX module path and required modules, all tests pass, and the application runs correctly using the IntelliJ run button.
- **Not a Java 17 Fix:** While these changes are not strictly related to Java 17, they address compatibility issues specific to Mac Silicon architecture.

#### Request for Feedback
- **Other Users' Experience:** This issue was observed on a M3 MacBook. It is essential to know if other users (particularly those on Mac Silicon) face similar issues.
- **Usefulness of the Change:** Feedback is requested on whether these changes improve compatibility and ease of setup for other users.

#### Instructions for Reviewers
1. **Set Up Alias in ~/.zshrc:**
   - Ensure the JavaFX path is correctly set in your environment variables.
   ```sh
   export PATH_TO_FX=~/path/to/javafx-sdk-17.0.7/lib
   ```
   - Apply changes with:
   ```sh
   source ~/.zshrc
   ```

2. **Run the Build:**
   - Verify if the build and tests pass when running the `build.gradle` file using the IntelliJ run button.

3. **Provide Feedback:**
   - Share your experiences and any issues encountered.
   - Confirm if this change resolves the problem and if it should be merged.

Please review the changes and provide your feedback on whether these updates resolve the issue and improve compatibility on Mac Silicon.