### PR TITLE
DG: Fix typo addressbook.commons -> address.commons

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -147,7 +147,7 @@ The `Storage` component,
 
 ### Common classes
 
-Classes used by multiple components are in the `seedu.addressbook.commons` package.
+Classes used by multiple components are in the `seedu.address.commons` package.
 
 --------------------------------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
I have updated the developer guide from `seedu.addressbook.commons` to `seedu.address.commons`.

As shown below, it should be `seedu.address.commons`.

<img width="356" alt="Screenshot 2024-07-17 at 4 26 03 AM" src="https://github.com/user-attachments/assets/ec962d43-ecf4-4396-97a2-fadb0da2d8aa">
