### PR TITLE
Update UG to say ‘latest jar’ instead of addressbook.jar

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -14,7 +14,7 @@ AddressBook Level 3 (AB3) is a **desktop app for managing contacts, optimized fo
 
 1. Ensure you have Java `17` or above installed in your Computer.
 
-1. Download the latest `addressbook.jar` from [here](https://github.com/se-edu/addressbook-level3/releases).
+1. Download the latest `.jar` file from [here](https://github.com/se-edu/addressbook-level3/releases).
 
 1. Copy the file to the folder you want to use as the _home folder_ for your AddressBook.
 


### PR DESCRIPTION
Fixes #23. Changes `UserGuide.md` by replacing "latest `addressbook.jar`" with "latest `.jar` file":

```diff
- 1. Download the latest `addressbook.jar` from [here](https://github.com/se-edu/addressbook-level3/releases).
+ 1. Download the latest `.jar` file from [here](https://github.com/se-edu/addressbook-level3/releases).

```