### PR TITLE
Fix logging typo

### DIFF
--- a/src/main/java/seedu/address/MainApp.java
+++ b/src/main/java/seedu/address/MainApp.java
@@ -176,7 +176,7 @@ public class MainApp extends Application {
 
     @Override
     public void stop() {
-        logger.info("============================ [ Stopping Address Book ] =============================");
+        logger.info("============================ [ Stopping AddressBook ] =============================");
         try {
             storage.saveUserPrefs(model.getUserPrefs());
         } catch (IOException e) {


### PR DESCRIPTION
When launching AB3 from terminal using java -jar, the start of logging says 'Initializing AddressBook' while the end says 'Stopping Address Book'.

Let's fix this inconsistency by changing it to 'Stopping AddressBook' in MainApp.java

![Screenshot 2024-07-22 at 12 57 16 PM](https://github.com/user-attachments/assets/e19c83af-64e2-47a5-aec1-1b56e43286ce)
